### PR TITLE
iemgr: Fix missing array include in alias

### DIFF
--- a/src/iemgr/iemgr_alias.cpp
+++ b/src/iemgr/iemgr_alias.cpp
@@ -2,6 +2,7 @@
 #include "iemgr_element.h"
 #include "iemgr_alias.h"
 
+#include <array>
 #include <string>
 
 #include <cassert>


### PR DESCRIPTION
Closes issue #27 